### PR TITLE
pull the correct platform image

### DIFF
--- a/bin/c3tk
+++ b/bin/c3tk
@@ -97,7 +97,7 @@ add_cmd() {
     [[ -n "${_image}" ]] || fail "$(add_usage)"
   fi
   ln -fs ${INSTALL_PATH}/c3tk ${INSTALL_PATH}/${_cmd}
-  docker pull ${_image}:${_tag:-latest}
+  docker pull --platform="linux/amd64" ${_image}:${_tag:-latest}
 }
 
 rm_cmd() {


### PR DESCRIPTION
if we don't specify the image to pull, it grabs the current arch...so we specify (saves storing the incorrect format locally and wasting space)