### PR TITLE
Escape backticks in usage

### DIFF
--- a/bin/c3tk
+++ b/bin/c3tk
@@ -46,7 +46,7 @@ Where cmd is either one of:
   list
   rm <name>
   shell <name>
-  X - where X is a cmd that was added via `add` or configured via .c3tk files
+  X - where X is a cmd that was added via \`add\` or configured via .c3tk files
 
 USAGE
 }


### PR DESCRIPTION
Without this, we get a mysterious error when we view the usage:

```
➜  c3tk git:(main) ✗ c3tk
/usr/local/bin/c3tk/bin/c3tk: line 38: add: command not found
c3tk <cmd> [OPTIONS|ARGS]

Where cmd is either one of:
  add <name> <image>
  configure
  fetch <url-to-.c3tk-file>
  install
  list
  rm <name>
  shell <name>
  X - where X is a cmd that was added via  or configured via .c3tk files

```