### PR TITLE
Makes c3tk a first-class citizen

### DIFF
--- a/bin/c3tk
+++ b/bin/c3tk
@@ -5,29 +5,20 @@ fail() {
   exit 1
 }
 
-install_cmds() {
-  for _cmd in "${@}"
-  do
-    [[ -x ${INSTALL_PATH}/${_cmd} ]] ||
-      ln -fs ${INSTALL_PATH}/c3tk ${INSTALL_PATH}/${_cmd}
-  done
-}
-
 installed_cmds() {
   find "${CONFIG_PATH}/cmds" -mindepth 1 -maxdepth 1 -type f | sed -e "s#${CONFIG_PATH}/cmds/##" | sort
 }
 
 install() {
-  mkdir -p "${INSTALL_PATH}" "${CONFIG_PATH}"/{cmds,config}
-  cp $0 "${INSTALL_PATH}/c3tk"
-  if (( $# == 0 ))
-  then
-    _cmds=($(installed_cmds))
-    install_cmds ${_cmds[@]}
-  fi
-  echo -e "\nAdd ${INSTALL_PATH} to your PATH:\n\n\texport PATH=\"${INSTALL_PATH}:\$PATH\"\n"
-  echo "install_path=${INSTALL_PATH}" > ${CONFIG_PATH}/install
+  mkdir -p "${INSTALL_PATH}" "${OPT_PATH}"/bin &&
+  cp $0 "${INSTALL_PATH}/c3tk" &&
+  echo "Installed \`${INSTALL_PATH}/c3tk\`" &&
+  echo -e "\nAdd $(paths) to your PATH:\n\n\texport PATH=\"\`c3tk paths\`:\$PATH\"\n" &&
   exit 0
+}
+
+paths() {
+  echo "${HOME}/.config/c3tk/bin:/opt/c3tk/bin:${INSTALL_PATH}"
 }
 
 docker_run() {
@@ -69,7 +60,7 @@ HELP
 add_cmd() {
   (( $# > 1 )) || fail "$(add_usage)"
 
-  local _cmd _image _tag
+  local _cmd _image _tag target_path
   _cmd="$1" && shift || fail "$(add_usage)"
   # TODO: If empty check if definition file already exists, if so symlink.
   if (( $# > 0 ))
@@ -96,7 +87,9 @@ add_cmd() {
     fi
     [[ -n "${_image}" ]] || fail "$(add_usage)"
   fi
-  ln -fs ${INSTALL_PATH}/c3tk ${INSTALL_PATH}/${_cmd}
+  target_path="${BIN_PATH}"
+
+  ln -fs ${INSTALL_PATH}/c3tk ${target_path}/${_cmd}
   docker pull --platform="linux/amd64" ${_image}:${_tag:-latest}
 }
 
@@ -107,8 +100,8 @@ rm_cmd() {
     then rm ${CONFIG_PATH}/cmds/${_cmd} 
     fi
 
-    if [[ -L ${INSTALL_PATH}/${_cmd} ]] 
-    then  rm ${INSTALL_PATH}/${_cmd}
+    if [[ -L ${BIN_PATH}/${_cmd} ]] 
+    then  rm ${BIN_PATH}/${_cmd}
     fi
   done
 }
@@ -200,11 +193,17 @@ cmd_exists() {
 env_setup() {
   true \
     "${CONFIG_PATH:="$HOME/.config/c3tk"}" \
+    "${BIN_PATH:="${CONFIG_PATH}/bin"}" \
+    "${OPT_PATH:="/opt/c3tk"}" \
     "${INSTALL_PREFIX:="/usr/local/bin"}" \
-    "${INSTALL_PATH:="${INSTALL_PREFIX}/c3tk/bin"}" \
+    "${INSTALL_PATH:="${INSTALL_PREFIX}"}" \
     "${IMAGE_TAG:="${TAG:-latest}"}"
 
   [[ "" == "${DEBUG}" ]] || set -xv
+}
+
+gen_config() {
+  mkdir -p "${CONFIG_PATH}"/{bin,cmds,config}
 
   touch ~/.saferc ~/.vaultrc ~/.flyrc
 }
@@ -217,12 +216,14 @@ dispatch_cmd() {
   local cmd="${1}"
   shift
 
+  gen_config
+
   case "${cmd}" in 
+    (paths) paths ;;
     (add) add_cmd "$@" ;;
     (c3tk) usage ;;
     (configure) configure "${@}" ;;
     (fetch) fetch_add "${@}" ;;
-    (install) install ;;
     (list) installed_cmds ;;
     (rm) rm_cmd "$@" ;;
     (shell) shell_for ${@} ;;
@@ -240,7 +241,13 @@ main() {
   # Allow this script to be symlinked as the actual command name :)
   cmd="$1" ; [[ ${0//*\/} == "c3tk" ]] && shift || cmd="${0//*\/}"
 
-  dispatch_cmd "${cmd}" $@
+  if [[ "install" == "${cmd}" ]]
+  then
+    # install is a special case, so we handle it explicitly.
+    install
+  else
+    dispatch_cmd "${cmd}" $@
+  fi
   
   exit 0
 }


### PR DESCRIPTION
This addresses #9

In order to make things play a little more nicely on the user
side of the quation, `c3tk install` now installs only the c3tk
script itself as /usr/local/bin/c3tk by default.

This also changes the default behavior of `c3tk add` such that
the symlinks are created within the user's ~/.config/c3tk/bin,
which is hopefully added to their path per the new instructions
that are output by `c3tk install`.

We've also added a `c3th paths` command to make the path update
a bit easier. It inludes the user's c3tk config bindir,
/opt/c3tk/bin (which isn't really a thing yet), and
/usr/local/bin (just for the sake of completeness).

So as to make sure that the user's ~/.config/c3tk doesn't end up
root-owned, we've removed the `install_cmds` function call from
`c3tk install`, and as this is the only place that it was used,
we've also removed the function altogether.

Finally, to make sure things are on the up-and-up, all commands
except for `c3tk install` now create the ~/.config/c3tk tree if
it does not exist.