### PR TITLE
How about a smarter configure?

### DIFF
--- a/lib/c3tk.bash
+++ b/lib/c3tk.bash
@@ -12,6 +12,10 @@ require() {
   done
 }
 
+defined() {
+  [[ -n "${1}" ]]
+}
+
 _c3tk_bootstrap() {
   # Load the list of all the things
   require libs

--- a/lib/configure.bash
+++ b/lib/configure.bash
@@ -20,17 +20,29 @@ gen_config() {
   touch ~/.saferc ~/.vaultrc ~/.flyrc
 }
 
-configure() {
-  local _config _group
-  for _config in $(find ~/.c3tk/config  -iname '*.c3tk')
+configure_group() {
+  local config="${1}"
+  local group=$(basename ${config} '.c3tk')
+
+  echo -e "\n${group}:\n$(printf '=%0.s' {1..80})"
+  while read _line
   do
-    _group=$(basename ${_config} '.c3tk')
-    echo -e "\n${_group}:\n$(printf '=%.0s' {1..80})"
-    while read _line 
-    do 
-      echo " => ${_line}"
-      $0 $_line
-    done < <(cat ${_config} | sed -e '/^[[:blank:]]*#/d;s/#.*//')
-  done
+    echo " => ${_line}"
+    ${0} ${_line}
+  done < <(cat ${config} | sed -e '/^[[:blank:]]*#/d;s/#.*//')
+}
+
+configure() {
+  local _config
+
+  if defined "${1}"
+  then
+    configure_group ${1}
+  else
+    for _config in $(find "${CONFIG_PATH}"/config -iname '*.c3tk')
+    do
+      configure_group "${_config}"
+    done
+  fi
 }
 

--- a/lib/fetch.bash
+++ b/lib/fetch.bash
@@ -23,6 +23,6 @@ fetch_add() {
   curl -f -s -o ${CONFIG_PATH}/config/${group}.c3tk $url 2>/dev/null || fail "transport error"
   echo "done"
 
-  configure
+  configure_group ${CONFIG_PATH}/config/${group}.c3tk
 }
 


### PR DESCRIPTION
`configure` now takes an optional argument, a FS path to a .c3tk
file.

With no argument, it loops over known group configs.

With an argument, it runs `configure_group` only for the specified
group config.

`fetch_add` has been updated to use the argument version, so
`c3tk fetch` doesn't reconfigure the whole world anymore.