### PR TITLE
Updated PATH suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ curl -o - https://raw.githubusercontent.com/c3tk/c3tk/main/bin/c3tk | sudo bash
 Follow the output of the instructions emitted from the install such as adding
 to your `PATH:
 ```
-grep -q c3tk ~/.profile || echo 'export PATH="$(c3tk paths):$PATH"' >> ~/.profile
+grep -q c3tk ~/.profile || echo '[[ -x /opt/c3tk/bin/c3tk ]] && export PATH="$(/opt/c3tk/bin/c3tk paths):$PATH"' >> ~/.profile
 ```
 Then open a new shell and start adding the commands you are interested in.
 

--- a/bin/c3tk
+++ b/bin/c3tk
@@ -44,7 +44,7 @@ install() {
     grab_files &&
     chmod +x ${INSTALL_PATH}/c3tk &&
     echo "Installed \`${INSTALL_PATH}/c3tk\`" &&
-    echo -e "\nAdd $(paths) to your PATH:\n\n\texport PATH=\"\$(/opt/c3tk/bin/c3tk paths):\$PATH\"\n" &&
+    echo -e "\nAdd $(paths) to your PATH:\n\n\t[[ -x ${INSTALL_PATH}/c3tk ]] && export PATH=\"\$(${INSTALL_PATH}/c3tk paths):\$PATH\"\n" &&
     exit 0
 }
 


### PR DESCRIPTION
1. Updated the `install` function such that it suggests a check for
   the existence of `${INSTALL_PATH}/c3tk`, then specifies
   `${INSTALL_PATH}/c3tk paths`. This first part is to ensure that
   this line doesn't execute when we do `c3tk shell`, as the user's
   `$HOME` is now mounted into the container. The second part is to
   get around a chicken-egg scenario whereby `c3tk paths` requires
   `c3tk` to already be in the path.
2. Updated the README with this same strategy.